### PR TITLE
Support for the linefeed

### DIFF
--- a/copyAsMarkdown.spBundle/command.plist
+++ b/copyAsMarkdown.spBundle/command.plist
@@ -88,7 +88,7 @@ class CopyAsMarkdown
         if (!empty($str)) {
           $str .= "|";
         }
-        $str .= $val;
+        $str .= str_replace(array("\n", "\r"), '', nl2br($val));
       }
       $result[] = $str;
     }

--- a/lib/CopyAsMarkdown/CopyAsMarkdown.php
+++ b/lib/CopyAsMarkdown/CopyAsMarkdown.php
@@ -81,7 +81,7 @@ class CopyAsMarkdown
         if (!empty($str)) {
           $str .= "|";
         }
-        $str .= $val;
+        $str .= str_replace(array("\n", "\r"), '', nl2br($val));
       }
       $result[] = $str;
     }

--- a/tests/lib/CopyAsMarkdown/CopyAsMarkdownTest.php
+++ b/tests/lib/CopyAsMarkdown/CopyAsMarkdownTest.php
@@ -33,6 +33,16 @@ d|e|f';
           array('d', 'e', 'f'),
         )));
   }
+
+  public function testCreateDataRows_ReturnLineFeedRemovedData_WhenHasLineFeedInData()
+  {
+    $expected = 'a|b1<br />b2<br />b3|c';
+    $this->assertEquals($expected, $this->copyAsMarkdown->createDataRows(array(
+          array('a', 'b1
+b2
+b3', 'c'),
+        )));
+  }
 }
 
 class CopyAsMarkdownExtended extends CopyAsMarkdown


### PR DESCRIPTION
refs : https://github.com/hypermkt/CopyAsMarkdownForSequelProBundle/issues/1

The markdown result get broken when the line feed was included in the data. So we can output valid markdown data by converting into br tag by nl2br from line feed.
