### PR TITLE
Fix 1 column tabling

### DIFF
--- a/copyAsMarkdown.spBundle/command.plist
+++ b/copyAsMarkdown.spBundle/command.plist
@@ -48,19 +48,13 @@ class CopyAsMarkdown
     $result = [];
     $str = '';
     foreach ($columns as $column) {
-      if (!empty($str)) {
-        $str .= "|";
-      }
-      $str .= $column;
+      $str .= "|" . $column;
     }
     $result[] = $str;
 
     $str = '';
     for($i=0; $i&lt;count($columns); $i++) {
-      if (!empty($str)) {
-        $str .= "|";
-      }
-      $str .= "---";
+      $str .= "|---";
     }
     $result[] = $str;
 
@@ -85,10 +79,7 @@ class CopyAsMarkdown
     foreach ($rows as $row) {
       $str = '';
       foreach ($row as $val) {
-        if (!empty($str)) {
-          $str .= "|";
-        }
-        $str .= str_replace(array("\n", "\r"), '', nl2br($val));
+        $str .= "|" . str_replace(array("\n", "\r"), '', nl2br($val));
       }
       $result[] = $str;
     }

--- a/lib/CopyAsMarkdown/CopyAsMarkdown.php
+++ b/lib/CopyAsMarkdown/CopyAsMarkdown.php
@@ -41,19 +41,13 @@ class CopyAsMarkdown
     $result = [];
     $str = '';
     foreach ($columns as $column) {
-      if (!empty($str)) {
-        $str .= "|";
-      }
-      $str .= $column;
+      $str .= "|" . $column;
     }
     $result[] = $str;
 
     $str = '';
     for($i=0; $i<count($columns); $i++) {
-      if (!empty($str)) {
-        $str .= "|";
-      }
-      $str .= "---";
+      $str .= "|---";
     }
     $result[] = $str;
 
@@ -78,10 +72,7 @@ class CopyAsMarkdown
     foreach ($rows as $row) {
       $str = '';
       foreach ($row as $val) {
-        if (!empty($str)) {
-          $str .= "|";
-        }
-        $str .= str_replace(array("\n", "\r"), '', nl2br($val));
+        $str .= "|" . str_replace(array("\n", "\r"), '', nl2br($val));
       }
       $result[] = $str;
     }

--- a/tests/lib/CopyAsMarkdown/CopyAsMarkdownTest.php
+++ b/tests/lib/CopyAsMarkdown/CopyAsMarkdownTest.php
@@ -13,15 +13,15 @@ class CopyAsMarkdownTest extends PHPUnit_Framework_TestCase
 
   public function testCreateHeaderRows()
   {
-    $expected = 'hoge|fuga
----|---';
+    $expected = '|hoge|fuga
+|---|---';
     $this->assertEquals($expected, $this->copyAsMarkdown->createHeaderRows(array('hoge', 'fuga')));
   }
 
   public function testCreateHeaderRows_WhenHasOneColumn()
   {
-    $expected = 'hoge|
----|';
+    $expected = '|hoge
+|---';
     $this->assertEquals($expected, $this->copyAsMarkdown->createHeaderRows(array('hoge')));
   }
 
@@ -33,8 +33,8 @@ class CopyAsMarkdownTest extends PHPUnit_Framework_TestCase
 
   public function testCreateDataRows()
   {
-    $expected = 'a|b|c
-d|e|f';
+    $expected = '|a|b|c
+|d|e|f';
     $this->assertEquals($expected, $this->copyAsMarkdown->createDataRows(array(
           array('a', 'b', 'c'),
           array('d', 'e', 'f'),
@@ -43,7 +43,7 @@ d|e|f';
 
   public function testCreateDataRows_WhenHasOneColumn()
   {
-    $expected = 'a|';
+    $expected = '|a';
     $this->assertEquals($expected, $this->copyAsMarkdown->createDataRows(array(
           array('a'),
         )));
@@ -51,7 +51,7 @@ d|e|f';
 
   public function testCreateDataRows_ReturnLineFeedRemovedData_WhenHasLineFeedInData()
   {
-    $expected = 'a|b1<br />b2<br />b3|c';
+    $expected = '|a|b1<br />b2<br />b3|c';
     $this->assertEquals($expected, $this->copyAsMarkdown->createDataRows(array(
           array('a', 'b1
 b2

--- a/tests/lib/CopyAsMarkdown/CopyAsMarkdownTest.php
+++ b/tests/lib/CopyAsMarkdown/CopyAsMarkdownTest.php
@@ -18,6 +18,13 @@ class CopyAsMarkdownTest extends PHPUnit_Framework_TestCase
     $this->assertEquals($expected, $this->copyAsMarkdown->createHeaderRows(array('hoge', 'fuga')));
   }
 
+  public function testCreateHeaderRows_WhenHasOneColumn()
+  {
+    $expected = 'hoge|
+---|';
+    $this->assertEquals($expected, $this->copyAsMarkdown->createHeaderRows(array('hoge')));
+  }
+
 
   public function testCalculateColumnCount()
   {
@@ -31,6 +38,14 @@ d|e|f';
     $this->assertEquals($expected, $this->copyAsMarkdown->createDataRows(array(
           array('a', 'b', 'c'),
           array('d', 'e', 'f'),
+        )));
+  }
+
+  public function testCreateDataRows_WhenHasOneColumn()
+  {
+    $expected = 'a|';
+    $this->assertEquals($expected, $this->copyAsMarkdown->createDataRows(array(
+          array('a'),
         )));
   }
 

--- a/tests/lib/CopyAsMarkdown/CopyAsMarkdownTest.php
+++ b/tests/lib/CopyAsMarkdown/CopyAsMarkdownTest.php
@@ -25,7 +25,6 @@ class CopyAsMarkdownTest extends PHPUnit_Framework_TestCase
     $this->assertEquals($expected, $this->copyAsMarkdown->createHeaderRows(array('hoge')));
   }
 
-
   public function testCalculateColumnCount()
   {
     $this->assertEquals(3, $this->copyAsMarkdown->calculateColumnCount(array(array('a', 'b', 'c'))));


### PR DESCRIPTION
When query result has only 1 column, like `select count(*) from table` result, markdown pasted is not enough to show table on GitHub issue, etc.

![2017-02-27 13 27 04](https://cloud.githubusercontent.com/assets/2294362/23348769/99893eb4-fcf0-11e6-90fc-22dcceba2814.png)  ![2017-02-27 13 27 18](https://cloud.githubusercontent.com/assets/2294362/23348770/998a98d6-fcf0-11e6-83d5-4b010ff39327.png)

So I try to fix it by putting '|' on head of each line.

![2017-02-27 13 27 32](https://cloud.githubusercontent.com/assets/2294362/23348790/c7fab610-fcf0-11e6-9973-e9bedeb0835c.png) ![2017-02-27 13 27 37](https://cloud.githubusercontent.com/assets/2294362/23348791/c7fd3f3e-fcf0-11e6-9326-a366410aa219.png)