### PR TITLE
Replace system php with brew's php

### DIFF
--- a/copyAsMarkdown.spBundle/command.plist
+++ b/copyAsMarkdown.spBundle/command.plist
@@ -5,7 +5,7 @@
 	<key>category</key>
 	<string>copyAs</string>
 	<key>command</key>
-	<string>#!/usr/bin/php
+	<string>#!/opt/homebrew/bin/php
 &lt;?php
 
 if (!isset($_ENV['TEST_ENV'])) {

--- a/lib/CopyAsMarkdown/CopyAsMarkdown.php
+++ b/lib/CopyAsMarkdown/CopyAsMarkdown.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/opt/homebrew/bin/php
 <?php
 
 if (!isset($_ENV['TEST_ENV'])) {


### PR DESCRIPTION
PHP has been removed in macOS Monterey.

The PHP community recommends brew's php, so change the php path from bundle php to brew's php path.

ref: [macOS 12.0 -where oh where is PHP | Apple Developer Forums](https://developer.apple.com/forums/thread/681907)